### PR TITLE
GeneExpression update

### DIFF
--- a/src/opengdc/parser/GeneExpressionQuantificationParser.java
+++ b/src/opengdc/parser/GeneExpressionQuantificationParser.java
@@ -110,6 +110,15 @@ public class GeneExpressionQuantificationParser extends BioParser {
                                         String entrez_tmp = GeneNames.getEntrezFromSymbol(gene_symbol);
                                         if (entrez_tmp != null)
                                             entrez = entrez_tmp;
+                                        else{
+                                            gene_symbol_tmp = GeneNames.getSymbolFromEnsemblID(ensembl_id_noversion);
+                                            if (gene_symbol_tmp != null){
+                                                gene_symbol = gene_symbol_tmp;
+                                                entrez_tmp = GeneNames.getEntrezFromSymbol(gene_symbol);
+                                                entrez = entrez_tmp;
+                                            }
+                                            else entrez= null;
+                                         }
                                         /***************************************************************************************************/
                                         String htseq_count = (ensembl2count.containsKey(ensembl_id)) ? ensembl2count.get(ensembl_id) : "NA";
                                         String fpkm_uq = (ensembl2fpkmuq.containsKey(ensembl_id)) ? ensembl2fpkmuq.get(ensembl_id) : "NA";


### PR DESCRIPTION
added control: if the entrez_id is not found, try to extract the
official gene symbol from ensembl_id, and the entrez_id from official
gene symbol, else keep the null value for entrez_id.