### PR TITLE
GeneNames update

### DIFF
--- a/src/opengdc/integration/GeneNames.java
+++ b/src/opengdc/integration/GeneNames.java
@@ -164,10 +164,11 @@ public class GeneNames {
     public static String getSymbolFromEnsemblID(String ensembl_id) {
         HashMap<String, String> data = getEnsemblId2Symbol();
         if (!data.isEmpty()) {
-            for (String gs: data.keySet()) {
-                if (gs.trim().toLowerCase().equals(ensembl_id.trim().toLowerCase()))
-                    return data.get(gs);
-            }
+//          for (String gs: data.keySet()) {
+//              if (gs.trim().toLowerCase().equals(ensembl_id.trim().toLowerCase()))
+//                  return data.get(gs);
+//          }
+            if(data.containsKey(ensembl_id)) return data.get(ensembl_id);
         }
         return null;
     }


### PR DESCRIPTION
updated the method getSymbolFromEnsemblID(..) for better performance
(the Ensembl_ID should always be in upper case).