### PR TITLE
Replaced aliquot_id path

### DIFF
--- a/src/opengdc/parser/CopyNumberSegmentParser.java
+++ b/src/opengdc/parser/CopyNumberSegmentParser.java
@@ -52,12 +52,13 @@ public class CopyNumberSegmentParser extends BioParser {
                     
                     String file_uuid = f.getName().split("_")[0];
                     HashSet<String> attributes = new HashSet<>();
-                    attributes.add("cases.samples.portions.analytes.aliquots.aliquot_id");
+                    String aliquot_id_path = "cases.samples.portions.analytes.aliquots.aliquot_id";
+                    attributes.add(aliquot_id_path);
                     HashMap<String, String> file_info = GDCQuery.retrieveExpInfoFromAttribute("files.file_id", file_uuid, attributes, 0);
                     String aliquot_uuid = "";
                     if (file_info != null)
-                        if (file_info.containsKey("aliquot_id"))
-                            aliquot_uuid = file_info.get("aliquot_id");
+                        if (file_info.containsKey(aliquot_id_path))
+                            aliquot_uuid = file_info.get(aliquot_id_path);
                     
                     if (!aliquot_uuid.trim().equals("")) {
                         try {

--- a/src/opengdc/parser/GeneExpressionQuantificationParser.java
+++ b/src/opengdc/parser/GeneExpressionQuantificationParser.java
@@ -49,12 +49,13 @@ public class GeneExpressionQuantificationParser extends BioParser {
                 if (getAcceptedInputFileFormats().contains(extension)) {
                     String file_uuid = f.getName().split("_")[0];
                     HashSet<String> attributes = new HashSet<>();
-                    attributes.add("cases.samples.portions.analytes.aliquots.aliquot_id");
+                    String aliquot_id_path = "cases.samples.portions.analytes.aliquots.aliquot_id";
+                    attributes.add(aliquot_id_path);
                     HashMap<String, String> file_info = GDCQuery.retrieveExpInfoFromAttribute("files.file_id", file_uuid, attributes, 0);
                     String aliquot_uuid = "";
                     if (file_info != null)
-                        if (file_info.containsKey("aliquot_id"))
-                            aliquot_uuid = file_info.get("aliquot_id");
+                        if (file_info.containsKey(aliquot_id_path))
+                            aliquot_uuid = file_info.get(aliquot_id_path);
                     fileUUID2aliquotUUID.put(file_uuid, aliquot_uuid);
                 }
             }

--- a/src/opengdc/parser/IsoformExpressionQuantificationParser.java
+++ b/src/opengdc/parser/IsoformExpressionQuantificationParser.java
@@ -53,12 +53,13 @@ public class IsoformExpressionQuantificationParser extends BioParser {
                     
                     String file_uuid = f.getName().split("_")[0];
                     HashSet<String> attributes = new HashSet<>();
-                    attributes.add("cases.samples.portions.analytes.aliquots.aliquot_id");
+                    String aliquot_id_path = "cases.samples.portions.analytes.aliquots.aliquot_id";
+                    attributes.add(aliquot_id_path);
                     HashMap<String, String> file_info = GDCQuery.retrieveExpInfoFromAttribute("files.file_id", file_uuid, attributes, 0);
                     String aliquot_uuid = "";
                     if (file_info != null)
-                        if (file_info.containsKey("aliquot_id"))
-                            aliquot_uuid = file_info.get("aliquot_id");
+                        if (file_info.containsKey(aliquot_id_path))
+                            aliquot_uuid = file_info.get(aliquot_id_path);
                     
                     if (!aliquot_uuid.trim().equals("")) {
                         try {

--- a/src/opengdc/parser/MethylationBetaValueParser.java
+++ b/src/opengdc/parser/MethylationBetaValueParser.java
@@ -55,12 +55,13 @@ public class MethylationBetaValueParser extends BioParser {
                     
                     String file_uuid = f.getName().split("_")[0];
                     HashSet<String> attributes = new HashSet<>();
-                    attributes.add("cases.samples.portions.analytes.aliquots.aliquot_id");
+                    String aliquot_id_path = "cases.samples.portions.analytes.aliquots.aliquot_id";
+                    attributes.add(aliquot_id_path);
                     HashMap<String, String> file_info = GDCQuery.retrieveExpInfoFromAttribute("files.file_id", file_uuid, attributes, 0);
                     String aliquot_uuid = "";
                     if (file_info != null)
-                        if (file_info.containsKey("aliquot_id"))
-                            aliquot_uuid = file_info.get("aliquot_id");
+                        if (file_info.containsKey(aliquot_id_path))
+                            aliquot_uuid = file_info.get(aliquot_id_path);
                     
                     if (!aliquot_uuid.trim().equals("")) {
                         try {

--- a/src/opengdc/parser/MiRNAExpressionQuantificationParser.java
+++ b/src/opengdc/parser/MiRNAExpressionQuantificationParser.java
@@ -56,12 +56,13 @@ public class MiRNAExpressionQuantificationParser extends BioParser {
                     
                     String file_uuid = f.getName().split("_")[0];
                     HashSet<String> attributes = new HashSet<>();
-                    attributes.add("cases.samples.portions.analytes.aliquots.aliquot_id");
+                    String aliquot_id_path = "cases.samples.portions.analytes.aliquots.aliquot_id";
+                    attributes.add(aliquot_id_path);
                     HashMap<String, String> file_info = GDCQuery.retrieveExpInfoFromAttribute("files.file_id", file_uuid, attributes, 0);
                     String aliquot_uuid = "";
                     if (file_info != null)
-                        if (file_info.containsKey("aliquot_id"))
-                            aliquot_uuid = file_info.get("aliquot_id");
+                        if (file_info.containsKey(aliquot_id_path))
+                            aliquot_uuid = file_info.get(aliquot_id_path);
                     
                     if (!aliquot_uuid.trim().equals("")) {
                         try {

--- a/src/opengdc/util/GDCQuery.java
+++ b/src/opengdc/util/GDCQuery.java
@@ -298,7 +298,7 @@ public class GDCQuery {
                         String[] attribute_split = attribute.split("\\.");
                         String searchForKey = attribute_split[attribute_split.length-1];
                         String val = searchFor(searchForKey, data_node_obj);
-                        info.put(searchForKey, val!=null ? val : "");
+                        info.put(attribute, val!=null ? val : "");
                     }
 
                     conn.disconnect();


### PR DESCRIPTION
Replaced aliquot_id path
(cases.samples.portions.analytes.aliquots.aliquot_id) in the map
“file_info” in all parser classes.
In GDCQuery class, replaced the variable ‘attribute’ instead of
‘searchForKey’, because this method is used also for the metadata
parsing, where we have to maintain the all path of the attributes.